### PR TITLE
Use raw strings for python 

### DIFF
--- a/helpers/ipynb_convert/languages.py
+++ b/helpers/ipynb_convert/languages.py
@@ -1,5 +1,5 @@
 languages = {
-    "python": {"ext": "py", "cchar": "#", "multiline_start": '"""', "multiline_end": '"""', "kernel_name": "python3"},
+    "python": {"ext": "py", "cchar": "#", "multiline_start": 'r"""', "multiline_end": '"""', "kernel_name": "python3"},
     "r": {"ext": "R", "cchar": "#", "multiline_start": '"', "multiline_end": '"', "kernel_name": "R"},
     "julia": {"ext": "jl", "cchar": "#", "multiline_start": '#=', "multiline_end": '=#', "kernel_name": "julia"},
     "java": {"ext": "java", "cchar": "//", "multiline_start": '/*', "multiline_end": '*/', "kernel_name": "java"},

--- a/plugin/jukit.vim
+++ b/plugin/jukit.vim
@@ -317,7 +317,6 @@ fun! s:set_mappings() abort
     endif
 endfun
 
-
 if type(g:jukit_mappings_ext_enabled) == 1
     let g:jukit_mappings_ext_enabled = [g:jukit_mappings_ext_enabled]
 endif
@@ -327,8 +326,6 @@ else
     let s:jukit_mappings_ext_aupat = '*.' . join(g:jukit_mappings_ext_enabled, ',*.')
 endif
 
-echom s:jukit_mappings_ext_aupat
-echom "autocmd BufEnter " . s:jukit_mappings_ext_aupat . " call s:set_mappings()"
 if g:jukit_mappings == 1
     exe "autocmd BufEnter " . s:jukit_mappings_ext_aupat . " call s:set_mappings()"
 endif

--- a/plugin/jukit.vim
+++ b/plugin/jukit.vim
@@ -16,6 +16,7 @@ let s:default_layout = {
 \}
 
 " jukit 
+let g:jukit_mappings_ext_enabled = get(g:, 'jukit_mappings_ext_enabled', '*')
 let g:jukit_shell_cmd = get(g:, 'jukit_shell_cmd', 'ipython3')
 let g:jukit_layout = get(g:, 'jukit_layout', s:default_layout)
 let g:jukit_terminal = get(g:, 'jukit_terminal', '')
@@ -195,7 +196,7 @@ command! -nargs=1 JukitOutHist :call jukit#splits#output_and_history(<q-args>)
 " Mappings
 """"""""""
 
-if g:jukit_mappings == 1
+fun! s:set_mappings() abort
     " splits
     if !hasmapto('jukit#splits#output', 'n')
         nnoremap <buffer> <leader>os <cmd>call jukit#splits#output()<cr>
@@ -314,4 +315,20 @@ if g:jukit_mappings == 1
     if !hasmapto("jukit#convert#save_nb_to_file(1,1,'pdf')", 'n')
         nnoremap <buffer> <leader>rpd <cmd>call jukit#convert#save_nb_to_file(1,1,'pdf')<cr>
     endif
+endfun
+
+
+if type(g:jukit_mappings_ext_enabled) == 1
+    let g:jukit_mappings_ext_enabled = [g:jukit_mappings_ext_enabled]
+endif
+if index(g:jukit_mappings_ext_enabled, '*') >= 0
+    let s:jukit_mappings_ext_aupat = '*'
+else
+    let s:jukit_mappings_ext_aupat = '*.' . join(g:jukit_mappings_ext_enabled, ',*.')
+endif
+
+echom s:jukit_mappings_ext_aupat
+echom "autocmd BufEnter " . s:jukit_mappings_ext_aupat . " call s:set_mappings()"
+if g:jukit_mappings == 1
+    exe "autocmd BufEnter " . s:jukit_mappings_ext_aupat . " call s:set_mappings()"
 endif

--- a/plugin/jukit.vim
+++ b/plugin/jukit.vim
@@ -198,120 +198,120 @@ command! -nargs=1 JukitOutHist :call jukit#splits#output_and_history(<q-args>)
 if g:jukit_mappings == 1
     " splits
     if !hasmapto('jukit#splits#output', 'n')
-        nnoremap <leader>os :call jukit#splits#output()<cr>
+        nnoremap <buffer> <leader>os <cmd>call jukit#splits#output()<cr>
     endif
     if !hasmapto('jukit#splits#term', 'n')
-        nnoremap <leader>ts :call jukit#splits#term()<cr>
+        nnoremap <buffer> <leader>ts <cmd>call jukit#splits#term()<cr>
     endif
     if !hasmapto('jukit#splits#history', 'n')
-        nnoremap <leader>hs :call jukit#splits#history()<cr>
+        nnoremap <buffer> <leader>hs <cmd>call jukit#splits#history()<cr>
     endif
     if !hasmapto('jukit#splits#output_and_history', 'n')
-        nnoremap <leader>ohs :call jukit#splits#output_and_history()<cr>
+        nnoremap <buffer> <leader>ohs <cmd>call jukit#splits#output_and_history()<cr>
     endif
     if !hasmapto('jukit#splits#close_history', 'n')
-        nnoremap <leader>hd :call jukit#splits#close_history()<cr>
+        nnoremap <buffer> <leader>hd <cmd>call jukit#splits#close_history()<cr>
     endif
     if !hasmapto('jukit#splits#close_output_split', 'n')
-        nnoremap <leader>od :call jukit#splits#close_output_split()<cr>
+        nnoremap <buffer> <leader>od <cmd>call jukit#splits#close_output_split()<cr>
     endif
     if !hasmapto('jukit#splits#close_output_and_history', 'n')
-        nnoremap <leader>ohd :call jukit#splits#close_output_and_history(1)<cr>
+        nnoremap <buffer> <leader>ohd <cmd>call jukit#splits#close_output_and_history(1)<cr>
     endif
     if !hasmapto('jukit#splits#out_hist_scroll(1)', 'n')
-        nnoremap <leader>j :call jukit#splits#out_hist_scroll(1)<cr>
+        nnoremap <buffer> <leader>j <cmd>call jukit#splits#out_hist_scroll(1)<cr>
     endif
     if !hasmapto('jukit#splits#out_hist_scroll(0)', 'n')
-        nnoremap <leader>k :call jukit#splits#out_hist_scroll(0)<cr>
+        nnoremap <buffer> <leader>k <cmd>call jukit#splits#out_hist_scroll(0)<cr>
     endif
     if !hasmapto('jukit#splits#show_last_cell_output', 'n')
-        nnoremap <leader>so :call jukit#splits#show_last_cell_output(1)<cr>
+        nnoremap <buffer> <leader>so <cmd>call jukit#splits#show_last_cell_output(1)<cr>
     endif
     if !hasmapto('jukit#ueberzug#set_default_pos', 'n')
-        nnoremap <leader>pos :call jukit#ueberzug#set_default_pos()<cr>
+        nnoremap <buffer> <leader>pos <cmd>call jukit#ueberzug#set_default_pos()<cr>
     endif
     if !hasmapto('jukit#splits#toggle_auto_hist', 'n')
-        nnoremap <leader>ah :call jukit#splits#toggle_auto_hist()<cr>
+        nnoremap <buffer> <leader>ah <cmd>call jukit#splits#toggle_auto_hist()<cr>
     endif
     if !hasmapto('jukit#layouts#set_layout', 'n')
-        nnoremap <leader>sl :call jukit#layouts#set_layout()<cr>
+        nnoremap <buffer> <leader>sl <cmd>call jukit#layouts#set_layout()<cr>
     endif
 
     " sending code
     if !hasmapto('jukit#send#line', 'n')
-        nnoremap <cr> :call jukit#send#line()<cr>
+        nnoremap <buffer> <cr> <cmd>call jukit#send#line()<cr>
     endif
     if !hasmapto('jukit#send#selection', 'v')
-        vnoremap <cr> :<C-U>call jukit#send#selection()<cr>
+        vnoremap <buffer> <cr> <cmd><C-U>call jukit#send#selection()<cr>
     endif
     if !hasmapto('jukit#send#section', 'n')
-        nnoremap <leader><space> :call jukit#send#section(0)<cr>
+        nnoremap <buffer> <leader><space> <cmd>call jukit#send#section(0)<cr>
     endif
     if !hasmapto('jukit#send#until_current_section', 'n')
-        nnoremap <leader>cc :call jukit#send#until_current_section()<cr>
+        nnoremap <buffer> <leader>cc <cmd>call jukit#send#until_current_section()<cr>
     endif
     if !hasmapto('jukit#send#all', 'n')
-        nnoremap <leader>all :call jukit#send#all()<cr>
+        nnoremap <buffer> <leader>all <cmd>call jukit#send#all()<cr>
     endif
 
     " cells
     if !hasmapto('jukit#cells#delete', 'n')
-        nnoremap <leader>cd :call jukit#cells#delete()<cr>
+        nnoremap <buffer> <leader>cd <cmd>call jukit#cells#delete()<cr>
     endif
     if !hasmapto('jukit#cells#split', 'n')
-        nnoremap <leader>cs :call jukit#cells#split()<cr>
+        nnoremap <buffer> <leader>cs <cmd>call jukit#cells#split()<cr>
     endif
     if !hasmapto('jukit#cells#create_below(0)', 'n')
-        nnoremap <leader>co :call jukit#cells#create_below(0)<cr>
+        nnoremap <buffer> <leader>co <cmd>call jukit#cells#create_below(0)<cr>
     endif
     if !hasmapto('jukit#cells#create_above(0)', 'n')
-        nnoremap <leader>cO :call jukit#cells#create_above(0)<cr>
+        nnoremap <buffer> <leader>cO <cmd>call jukit#cells#create_above(0)<cr>
     endif
     if !hasmapto('jukit#cells#create_below(1)', 'n')
-        nnoremap <leader>ct :call jukit#cells#create_below(1)<cr>
+        nnoremap <buffer> <leader>ct <cmd>call jukit#cells#create_below(1)<cr>
     endif
     if !hasmapto('jukit#cells#create_above(1)', 'n')
-        nnoremap <leader>cT :call jukit#cells#create_above(1)<cr>
+        nnoremap <buffer> <leader>cT <cmd>call jukit#cells#create_above(1)<cr>
     endif
     if !hasmapto('jukit#cells#merge_above', 'n')
-        nnoremap <leader>cM :call jukit#cells#merge_above()<cr>
+        nnoremap <buffer> <leader>cM <cmd>call jukit#cells#merge_above()<cr>
     endif
     if !hasmapto('jukit#cells#merge_below', 'n')
-        nnoremap <leader>cm :call jukit#cells#merge_below()<cr>
+        nnoremap <buffer> <leader>cm <cmd>call jukit#cells#merge_below()<cr>
     endif
     if !hasmapto('jukit#cells#move_up', 'n')
-        nnoremap <leader>ck :call jukit#cells#move_up()<cr>
+        nnoremap <buffer> <leader>ck <cmd>call jukit#cells#move_up()<cr>
     endif
     if !hasmapto('jukit#cells#move_down', 'n')
-        nnoremap <leader>cj :call jukit#cells#move_down()<cr>
+        nnoremap <buffer> <leader>cj <cmd>call jukit#cells#move_down()<cr>
     endif
     if !hasmapto('jukit#cells#delete_outputs(0)', 'n')
-        nnoremap <leader>ddo :call jukit#cells#delete_outputs(0)<cr>
+        nnoremap <buffer> <leader>ddo <cmd>call jukit#cells#delete_outputs(0)<cr>
     endif
     if !hasmapto('jukit#cells#delete_outputs(1)', 'n')
-        nnoremap <leader>dda :call jukit#cells#delete_outputs(1)<cr>
+        nnoremap <buffer> <leader>dda <cmd>call jukit#cells#delete_outputs(1)<cr>
     endif
     if !hasmapto('jukit#cells#jump_to_next_cell', 'n')
-        nnoremap <leader>J :call jukit#cells#jump_to_next_cell()<cr>
+        nnoremap <buffer> <leader>J <cmd>call jukit#cells#jump_to_next_cell()<cr>
     endif
     if !hasmapto('jukit#cells#jump_to_previous_cell', 'n')
-        nnoremap <leader>K :call jukit#cells#jump_to_previous_cell()<cr>
+        nnoremap <buffer> <leader>K <cmd>call jukit#cells#jump_to_previous_cell()<cr>
     endif
 
     " ipynb conversion
     if !hasmapto('jukit#convert#notebook_convert("jupyter-notebook")', 'n')
-        nnoremap <leader>np :call jukit#convert#notebook_convert("jupyter-notebook")<cr>
+        nnoremap <buffer> <leader>np <cmd>call jukit#convert#notebook_convert("jupyter-notebook")<cr>
     endif
     if !hasmapto("jukit#convert#save_nb_to_file(0,1,'html')", 'n')
-        nnoremap <leader>ht :call jukit#convert#save_nb_to_file(0,1,'html')<cr>
+        nnoremap <buffer> <leader>ht <cmd>call jukit#convert#save_nb_to_file(0,1,'html')<cr>
     endif
     if !hasmapto("jukit#convert#save_nb_to_file(0,1,'pdf')", 'n')
-        nnoremap <leader>pd :call jukit#convert#save_nb_to_file(0,1,'pdf')<cr>
+        nnoremap <buffer> <leader>pd <cmd>call jukit#convert#save_nb_to_file(0,1,'pdf')<cr>
     endif
     if !hasmapto("jukit#convert#save_nb_to_file(1,1,'html')", 'n')
-        nnoremap <leader>rht :call jukit#convert#save_nb_to_file(1,1,'html')<cr>
+        nnoremap <buffer> <leader>rht <cmd>call jukit#convert#save_nb_to_file(1,1,'html')<cr>
     endif
     if !hasmapto("jukit#convert#save_nb_to_file(1,1,'pdf')", 'n')
-        nnoremap <leader>rpd :call jukit#convert#save_nb_to_file(1,1,'pdf')<cr>
+        nnoremap <buffer> <leader>rpd <cmd>call jukit#convert#save_nb_to_file(1,1,'pdf')<cr>
     endif
 endif


### PR DESCRIPTION
When using latex inside a markdown cell, exporting the notebook to python may trigger an invalid escape sequence.