### PR TITLE
fix(backend): enable tight bbox

### DIFF
--- a/helpers/matplotlib-backend-kitty/backend.mplstyle
+++ b/helpers/matplotlib-backend-kitty/backend.mplstyle
@@ -5,3 +5,4 @@ axes.facecolor : cccccc
 axes.titlecolor : cccccc
 axes.labelcolor : cccccc
 savefig.facecolor : (0,0,0,0)
+savefig.bbox : tight


### PR DESCRIPTION
The current behavior may crop labels when plotting. For instance:
![image](https://user-images.githubusercontent.com/84649544/206079514-6ac0e71c-18ea-4bb2-9ebc-87b6d5d9fa37.png)
(labels at the bottom are also cut in this example, though only slightly)
The same plot with the proposed behavior:
![image](https://user-images.githubusercontent.com/84649544/206079745-58a9195e-2b6b-4619-8649-6c421ad7ed34.png)
I've only changed kitty's backend because I don't know if it affects the other one. I also don't know if it may break something else. According to matplotlib's documentation, "`tight` is incompatible with pipe-based animation backends but will work with those based on temporary files", but I don't think this affects jukit in any way.